### PR TITLE
Refactor PostsController to use PostRepository

### DIFF
--- a/server/SocialNetwork/SocialNetwork/Controllers/PostsController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/PostsController.cs
@@ -3,6 +3,7 @@ using SocialNetwork.Models.Database;
 
 // Hay que especificar el namespace de dónde se encuentra la entidad
 using SocialNetwork.Models.Database.Entities;
+using SocialNetwork.Models.DataBase.Repositories;
 
 namespace SocialNetwork.Controllers;
 
@@ -10,67 +11,44 @@ namespace SocialNetwork.Controllers;
 [ApiController]
 public class PostsController : ControllerBase {
 
-    // Inyección del DbContext
-    private readonly SocialNetworkContext _dbContext;
-    public PostsController(SocialNetworkContext dbContext) {
-        _dbContext = dbContext;
+    // Inyección del Repositorio
+    private readonly PostRepository _postRepository;
+    public PostsController(PostRepository postRepository) {
+        _postRepository = postRepository;
     }
 
     // GET: api/posts
     [HttpGet]
-    public IEnumerable<Post> GetAllPosts() {
-        return _dbContext.Post.ToList();
+    public async Task<IEnumerable<Post>> GetAllPosts() {
+        return await _postRepository.GetPostsAsync();
     }
 
     // GET: api/posts/by-user/5
     [HttpGet("by-user/{userId:long}")]
-    public List<Post> GetPostsByUserId(long userId) {
-        List<Post>? userPosts = _dbContext.Post.Where(x => x.UserId == userId).ToList();
-
-        return userPosts;
+    public async Task<IEnumerable<Post>> GetPostsByUserId(long userId) {
+        return await _postRepository.GetPostsByUserIdAsync(userId);
     }
 
     // GET: api/posts/5
     [HttpGet("{id}")]
-    public ActionResult<Post> GetPostById(long id) {
-        Post? post = _dbContext.Post.Find(id);
-
-        return post is null ? NotFound() : post;
+    public async Task<Post?> GetPostById(long id) {
+        return await _postRepository.GetPostByIdAsync(id);
     }
 
     [HttpPost]
     // Los parámetros son la Entidad (Post) y un objeto nuevo (post) que se crea
     // apartir del JSON que devuelve la petición POST
-    public ActionResult<Post> AddPost([FromBody] Post post) {
-        _dbContext.Post.Add(post);
-        _dbContext.SaveChanges();
-
-        return Created($"/posts/{post.Id}", post);
+    public async Task<bool> AddPost([FromBody] Post post) {
+        return await _postRepository.AddPostAsync(post);
+    }
+    
+    [HttpPut]
+    public async Task<bool> UpdatePost([FromBody] Post newPost) {
+        return await _postRepository.UpdatePostAsync(newPost);
     }
 
-    [HttpPut("{id}")]
-    public ActionResult UpdatePost(long id, [FromBody] Post newPost) {
-        Post? oldPost = _dbContext.Post.Find(id);
-
-        if (oldPost is not null) {
-            oldPost.Title = newPost.Title;
-            oldPost.Description = newPost.Description;
-            oldPost.PicturePath = newPost.PicturePath;
-
-            _dbContext.Post.Update(newPost);
-            _dbContext.SaveChanges();
-        }
-
-        return NoContent();
-    }
-
-    [HttpDelete("{id}")]
-    public void DeletePost(long id) {
-        Post? post = _dbContext.Post.Find(id);
-
-        if (post is not null) {
-            _dbContext.Post.Remove(post);
-            _dbContext.SaveChanges();
-        }
+    [HttpDelete]
+    public async Task<bool> DeletePost([FromBody] Post post) {
+        return await _postRepository.DeletePostAsync(post);
     }
 }

--- a/server/SocialNetwork/SocialNetwork/Models/DataBase/Repositories/PostRepository.cs
+++ b/server/SocialNetwork/SocialNetwork/Models/DataBase/Repositories/PostRepository.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SocialNetwork.Models.Database;
+using SocialNetwork.Models.Database.Entities;
+
+namespace SocialNetwork.Models.DataBase.Repositories;
+public class PostRepository : BaseRepository<Post, long> {
+    public PostRepository(SocialNetworkContext context) : base(context) {
+    }
+
+    // METODO SELECT * FROM POST ================
+    public async Task<ICollection<Post>> GetPostsAsync() {
+        return await GetAllAsync();
+    }
+
+    // METODO SELECT BY USER ID ================
+    public async Task<ICollection<Post>> GetPostsByUserIdAsync(long userId) {
+        return await GetQueryable()
+            .Where(post => post.UserId == userId)
+            .ToArrayAsync();
+    }
+
+    // METODO SELECT BY ID ================
+    public async Task<Post?> GetPostByIdAsync(long id) {
+        return await GetByIdAsync(id);
+    }
+
+    // METODO INSERT ================
+    public async Task<bool> AddPostAsync(Post post) {
+        await InsertAsync(post);
+        return await SaveAsync();
+    }
+
+    // METODO UPDATE ================
+    public async Task<bool> UpdatePostAsync(Post newPost) {
+        if (await ExistAsync(newPost.Id)) {
+            await UpdateAsync(newPost);
+            return await SaveAsync();
+        } else {
+            return false;
+        }
+    }
+
+    // METODO DELETE ================
+    public async Task<bool> DeletePostAsync(Post post) {
+        if (await ExistAsync(post.Id)) {
+            await DeleteAsync(post);
+            return await SaveAsync();
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/server/SocialNetwork/SocialNetwork/Program.cs
+++ b/server/SocialNetwork/SocialNetwork/Program.cs
@@ -1,4 +1,5 @@
 using SocialNetwork.Models.Database;
+using SocialNetwork.Models.DataBase.Repositories;
 
 namespace SocialNetwork;
 
@@ -11,6 +12,10 @@ public class Program
         // Add services to the container.
         builder.Services.AddControllers();
         builder.Services.AddOpenApi();
+
+        // Repositorios
+        builder.Services.AddScoped<PostRepository>();
+        //builder.Services.AddScoped<UserRepository>();
 
         // Añadimos el DbContext al servicio de inyeccion de dependencias
         // Tiene que ser scoped para que cierre la conexion y limpie


### PR DESCRIPTION
Replaced direct DbContext usage in PostsController with PostRepository for better separation of concerns and maintainability. Added PostRepository implementation with async CRUD methods. Registered PostRepository in dependency injection container in Program.cs.