### PR TITLE
Refactor UsersController to use UnitOfWork

### DIFF
--- a/server/SocialNetwork/SocialNetwork/Controllers/UsersController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/UsersController.cs
@@ -10,58 +10,58 @@ namespace SocialNetwork.Controllers;
 public class UsersController : ControllerBase
 {
     // Inyección de UserRepository 
-    private readonly UserRepository _userRepository;
+    private readonly UnitOfWork _unitOfWork;
 
-    public UsersController(UserRepository userRepository)
+    public UsersController(UnitOfWork unitOfWork)
     {
-        _userRepository = userRepository;
+        _unitOfWork = unitOfWork;
     }
 
     //GET: api/users
     [HttpGet]
     public async Task<IEnumerable<User>> GetAllUsers(){
-        return await _userRepository.GetUserAsync();
+        return await _unitOfWork.UserRepository.GetUserAsync();
     }
 
     // GET
     [HttpGet("{id:long}")]
     public async Task<User?> GetUserById(long id)
     {
-        return await _userRepository.GetUserByIdAsync(id);
+        return await _unitOfWork.UserRepository.GetUserByIdAsync(id);
     }
 
     // Get by nickname
     [HttpGet("by-nickname/{nickname}")]
     public async Task<User?> GetUserByNickname(string nickname)
     {
-        return await _userRepository.GetUserByNicknameAsync(nickname);
+        return await _unitOfWork.UserRepository.GetUserByNicknameAsync(nickname);
     }
 
     // Get by email
     [HttpGet("by-email/{email}")]
     public async Task<User?> GetUserByEmail(string email)
     {
-        return await _userRepository.GetUserByEmailAsync(email);
+        return await _unitOfWork.UserRepository.GetUserByEmailAsync(email);
     }
 
     // POST
     [HttpPost]
     public async Task<bool> AddUser([FromBody] User user)
     {
-        return await _userRepository.AddUserAsync(user);
+        return await _unitOfWork.UserRepository.AddUserAsync(user);
     }
 
     // PUT
     [HttpPut]
     public async Task<bool> UpdateUser([FromBody] User newUser)
     {
-        return await _userRepository.UpdateUserAsync(newUser);
+        return await _unitOfWork.UserRepository.UpdateUserAsync(newUser);
     }
 
     // DELETE
     [HttpDelete]
     public async Task<bool> DeleteUser([FromBody] User user)
     {
-        return await _userRepository.DeleteUserAsync(user);
+        return await _unitOfWork.UserRepository.DeleteUserAsync(user);
     }
 }


### PR DESCRIPTION
Replaced direct dependency on UserRepository with UnitOfWork in UsersController. All repository calls are now accessed through UnitOfWork to improve maintainability and support for transactional operations.