### PR TITLE
Add authorization to API controllers

### DIFF
--- a/server/SocialNetwork/SocialNetwork/Controllers/FilesController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/FilesController.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using System.IO;
 
 namespace SocialNetwork.Controllers;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class FilesController : ControllerBase

--- a/server/SocialNetwork/SocialNetwork/Controllers/FollowingController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/FollowingController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using SocialNetwork.Models;                         // Para acceder a la clase User
 using SocialNetwork.Models.Database;
 using SocialNetwork.Models.Dtos;
@@ -6,6 +7,7 @@ using System.Threading.Tasks;
 
 namespace SocialNetwork.Controllers
 {
+    [Authorize]
     [Route("api/[controller]")]
     [ApiController]
     public class FollowingController : ControllerBase

--- a/server/SocialNetwork/SocialNetwork/Controllers/PostsController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/PostsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using SocialNetwork.Models.Database;
 
 // Hay que especificar el namespace de dónde se encuentra la entidad
@@ -8,6 +9,7 @@ using SocialNetwork.Models.Dtos.Posts;
 
 namespace SocialNetwork.Controllers;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class PostsController : ControllerBase {

--- a/server/SocialNetwork/SocialNetwork/Controllers/UsersController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/UsersController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using SocialNetwork.Models.Database;
 using SocialNetwork.Models.Database.Entities;
 using SocialNetwork.Models.Dtos.Users;
 
 namespace SocialNetwork.Controllers;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class UsersController : ControllerBase {
@@ -47,6 +49,7 @@ public class UsersController : ControllerBase {
     }
 
     // POST
+    [AllowAnonymous]
     [HttpPost]
     public async Task<ActionResult<AddUserDto>> AddUser([FromBody] AddUserDto dto) {
         User user = new User {


### PR DESCRIPTION
Apply [Authorize] to FilesController, FollowingController, PostsController and UsersController and add the Microsoft.AspNetCore.Authorization using directive where needed. This secures controller endpoints by default while keeping the user registration endpoint open via [AllowAnonymous] on UsersController POST AddUser.