### PR TITLE
Require admin role for user deletion

### DIFF
--- a/server/SocialNetwork/SocialNetwork/Controllers/UsersController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/UsersController.cs
@@ -80,6 +80,7 @@ public class UsersController : ControllerBase {
     }
 
     // DELETE
+    [Authorize(Roles = "admin")]
     [HttpDelete]
     public async Task DeleteUser([FromBody] User user) {
         await _unitOfWork.UserRepository.DeleteAsync(user);

--- a/server/SocialNetwork/SocialNetwork/Program.cs
+++ b/server/SocialNetwork/SocialNetwork/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.IdentityModel.Tokens;
 using SocialNetwork.Models.Database;
 using SocialNetwork.Models.Database.Repositories;
 using SocialNetwork.Models.Database.Seeder;
+using System.Security.Claims;
 using System.Text;
 
 namespace SocialNetwork;
@@ -47,6 +48,7 @@ public class Program
                 ValidateAudience = false,
                 // Indicamos la clave
                 IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+                RoleClaimType = ClaimTypes.Role // para [Authorize(Roles="...")]
             };
         });
 


### PR DESCRIPTION
Restrict the DELETE user endpoint by adding [Authorize(Roles = "admin")] to UsersController.DeleteUser. Configure JWT token validation to recognize role claims by setting TokenValidationParameters.RoleClaimType = ClaimTypes.Role and adding the System.Security.Claims using. This enables role-based authorization (e.g., Roles="admin") to work with issued JWTs.