### PR TITLE
Include avatar path in JWT claims

### DIFF
--- a/server/SocialNetwork/SocialNetwork/Controllers/AuthController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/AuthController.cs
@@ -47,7 +47,8 @@ namespace SocialNetwork.Controllers
                         {
                             { "id", user.Id.ToString() },
                             { ClaimTypes.Name, user.Nickname },
-                            { ClaimTypes.Role, user.Role }
+                            { ClaimTypes.Role, user.Role },
+                            { "AvatarPath", user.AvatarPath }
                         },
                     // Aquí indicamos cuándo caduca el token
                     Expires = DateTime.UtcNow.AddDays(5),


### PR DESCRIPTION
Add the user's AvatarPath to the JWT claims in AuthController so the generated token includes a reference to the user's avatar. This makes the avatar path available to clients reading the token payload; token expiration remains unchanged.