### PR TITLE
Add auth redirection guard and login redirect

### DIFF
--- a/client/social-network/src/app/app.routes.ts
+++ b/client/social-network/src/app/app.routes.ts
@@ -6,13 +6,14 @@ import { Login } from './pages/login/login';
 import { Profile } from './pages/profile/profile';
 import { Landing } from './pages/landing/landing';
 import { Register } from './pages/register/register';
+import { redirectionGuard } from './guards/redirection-guard';
 
 export const routes: Routes = [
     { path: 'about', component: About },
-    { path: 'admin', component: Admin },
+    { path: 'admin', component: Admin, canActivate: [redirectionGuard] },
     { path: 'feed', component: Feed },
     { path: 'login', component: Login },
-    { path: 'profile', component: Profile },
+    { path: 'profile', component: Profile, canActivate: [redirectionGuard] },
     { path: 'landing', component: Landing },
     { path: 'register', component: Register },
     { path: '', redirectTo: 'landing', pathMatch: 'full' }

--- a/client/social-network/src/app/guards/redirection-guard.spec.ts
+++ b/client/social-network/src/app/guards/redirection-guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { redirectionGuard } from './redirection-guard';
+
+describe('redirectionGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => redirectionGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/client/social-network/src/app/guards/redirection-guard.ts
+++ b/client/social-network/src/app/guards/redirection-guard.ts
@@ -1,0 +1,18 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+
+export const redirectionGuard: CanActivateFn = (route, state) => {
+  const router = inject(Router);
+
+  // Verificamos si existe el token JWT en localStorage
+  const token = localStorage.getItem('jwt');
+
+  if (token) {
+    // Si hay token, permitimos acceso
+    return true;
+  } else {
+    // Si no hay token, redirigimos a login con queryParam para ir a feed después
+    router.navigate(['/login'], { queryParams: { redirectTo: state.url } });
+    return false;
+  }
+};

--- a/client/social-network/src/app/pages/login/login.ts
+++ b/client/social-network/src/app/pages/login/login.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { RouterLink } from "@angular/router";
+import { RouterLink, Router, ActivatedRoute } from "@angular/router";
 import { AuthRequest } from '../../models/auth-request';
 import { AuthService } from '../../services/auth';
 import { FormsModule } from '@angular/forms';
@@ -18,8 +18,12 @@ export class Login implements OnInit, OnDestroy {
   password: string = '';
   jwt: string = '';
 
-  // Inyectamos el servicio de autenticación para el login
-  constructor(private authService: AuthService) {}
+  // Inyectamos los servicios necesarios
+  constructor(
+    private authService: AuthService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
 
   // Método del submit del formulario de login
   async submit() {
@@ -30,10 +34,12 @@ export class Login implements OnInit, OnDestroy {
 
     const result = await this.authService.login(authData);
 
-    // Si el login es correcto, se guarda el JWT en el servicio de autenticación
+    // Si el login es correcto, se guarda el JWT y redirige al feed
     if (result.success) {
       this.jwt = result.data.accessToken;
-      // TO DO: Redirigir a la página del feed
+      // Obtenemos el parámetro redirectTo si existe, si no vamos a feed
+      const redirectTo = this.route.snapshot.queryParams['redirectTo'] || '/feed';
+      this.router.navigateByUrl(redirectTo);
     } else {
       alert('El usuario o la contraseña son incorrectos');
     }

--- a/client/social-network/src/app/services/auth.ts
+++ b/client/social-network/src/app/services/auth.ts
@@ -17,6 +17,8 @@ export class AuthService {
 
     if (result.success) {
       this.api.jwt = result.data.accessToken;
+      // Se guarda el token en localStorage
+      localStorage.setItem('jwt', result.data.accessToken);
     }
 
     return result;

--- a/server/SocialNetwork/SocialNetwork/Controllers/PostsController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/PostsController.cs
@@ -1,12 +1,10 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using SocialNetwork.Models.Database;
 using SocialNetwork.Models.Database.Entities;
 using SocialNetwork.Models.Dtos.Posts;
 
 namespace SocialNetwork.Controllers;
 
-[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class PostsController : ControllerBase {

--- a/server/SocialNetwork/SocialNetwork/Program.cs
+++ b/server/SocialNetwork/SocialNetwork/Program.cs
@@ -47,7 +47,7 @@ public class Program
                 // para qué propósito está destinado el token, lo desactivamos
                 ValidateAudience = false,
                 // Indicamos la clave
-                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key)),
                 RoleClaimType = ClaimTypes.Role // para [Authorize(Roles="...")]
             };
         });


### PR DESCRIPTION
Introduce a redirectionGuard (with unit spec) that checks for a JWT in localStorage and redirects unauthenticated users to /login with a redirectTo query param. Apply the guard to admin and profile routes. Update Login to save/handle redirectTo after successful login and inject Router/ActivatedRoute. Persist JWT in localStorage from AuthService. Remove the [Authorize] attribute from PostsController and apply a small formatting tweak to Program.cs signing key options.