### PR TITLE
Centralize JWT in AuthService, add remember-me

### DIFF
--- a/client/social-network/src/app/app.ts
+++ b/client/social-network/src/app/app.ts
@@ -1,7 +1,7 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { RouterOutlet, RouterLinkWithHref } from '@angular/router';
 import { Post } from './models/post';
-import { ApiService } from './services/api';
+import { AuthService } from './services/auth';
 
 @Component({
   selector: 'app-root',
@@ -9,6 +9,16 @@ import { ApiService } from './services/api';
   templateUrl: './app.html',
   styleUrl: './app.css'
 })
-export class App {
+export class App implements OnInit {
   protected readonly title = signal('social-network');
+
+  constructor(private authService: AuthService) {}
+
+  ngOnInit() {
+    // Cargamos el JWT del localStorage al iniciar la app
+    const jwt = localStorage.getItem('jwt');
+    if (jwt) {
+      this.authService.setJwt(jwt);
+    }
+  }
 }

--- a/client/social-network/src/app/guards/redirection-guard.ts
+++ b/client/social-network/src/app/guards/redirection-guard.ts
@@ -1,14 +1,13 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
+import { AuthService } from '../services/auth';
 
 export const redirectionGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
+  const authService = inject(AuthService);
 
-  // Verificamos si existe el token JWT en localStorage
-  const token = localStorage.getItem('jwt');
-
-  if (token) {
-    // Si hay token, permitimos acceso
+  // Verificamos si existe el token JWT en el servicio o en localStorage
+  if (authService.jwt) {
     return true;
   } else {
     // Si no hay token, redirigimos a login con queryParam para ir a feed después

--- a/client/social-network/src/app/pages/login/login.html
+++ b/client/social-network/src/app/pages/login/login.html
@@ -14,7 +14,7 @@
                     <span>Contraseña <span class="required">*</span></span>
                     <input type="password" [(ngModel)]="password" [ngModelOptions]="{standalone: true}">
                     <div class="div-checkbox">
-                        <input type="checkbox" id="keep-logged-checkbox"><span class="small-text">Mantener la sesión iniciada</span>
+                        <input type="checkbox" id="remember-me" [(ngModel)]="rememberMeChecked" [ngModelOptions]="{standalone: true}"><span class="small-text">Mantener la sesión iniciada</span>
                     </div>
                 </div>
                 <div class="div-input">
@@ -25,11 +25,3 @@
         </div>
     </form>
 </div>
-
-    @if (jwt) {
-        <h4>El token de acceso es:</h4>
-        <p>{{jwt}}</p>
-    }
-    @else {
-        <h4>No estás autenticado</h4>
-    }

--- a/client/social-network/src/app/pages/login/login.ts
+++ b/client/social-network/src/app/pages/login/login.ts
@@ -16,7 +16,7 @@ export class Login implements OnInit, OnDestroy {
   // Variables del formulario de login
   nickname: string = '';
   password: string = '';
-  jwt: string = '';
+  rememberMeChecked: boolean = false;
 
   // Inyectamos los servicios necesarios
   constructor(
@@ -32,11 +32,10 @@ export class Login implements OnInit, OnDestroy {
       password: this.password
     };
 
-    const result = await this.authService.login(authData);
+    const result = await this.authService.login(authData, this.rememberMeChecked);
 
-    // Si el login es correcto, se guarda el JWT y redirige al feed
+    // Si el login es correcto, redirige al feed
     if (result.success) {
-      this.jwt = result.data.accessToken;
       // Obtenemos el parámetro redirectTo si existe, si no vamos a feed
       const redirectTo = this.route.snapshot.queryParams['redirectTo'] || '/feed';
       this.router.navigateByUrl(redirectTo);

--- a/client/social-network/src/app/services/auth.ts
+++ b/client/social-network/src/app/services/auth.ts
@@ -9,16 +9,29 @@ import { Result } from '../models/result';
   providedIn: 'root',
 })
 export class AuthService {
+  // JWT en memoria (muere al cerrar la página)
+  jwt: string | null = null;
   
   constructor(private api: ApiService) {}
 
-  async login(authData: AuthRequest): Promise<Result<AuthResponse>> {
+  // Establece el JWT que viene del localStorage
+  setJwt(jwt: string): void {
+    this.jwt = jwt;
+    this.api.jwt = jwt;
+  }
+
+  async login(authData: AuthRequest, rememberMe: boolean = false): Promise<Result<AuthResponse>> {
     const result = await this.api.post<AuthResponse>('auth/login', authData);
 
     if (result.success) {
-      this.api.jwt = result.data.accessToken;
-      // Se guarda el token en localStorage
-      localStorage.setItem('jwt', result.data.accessToken);
+      const token = result.data.accessToken;
+      this.jwt = token;
+      this.api.jwt = token;
+      
+      // Se guarda el token en localStorage solo si rememberMe es true
+      if (rememberMe) {
+        localStorage.setItem('jwt', token);
+      }
     }
 
     return result;


### PR DESCRIPTION
Centralize token handling in AuthService and add an optional "remember me" flow. App now loads a saved JWT into AuthService on init; AuthService exposes an in-memory jwt, a setJwt() helper, and login(...) accepts a rememberMe flag to persist the token to localStorage only when requested. The route guard now checks AuthService.jwt instead of reading localStorage directly. Login page and component were updated to bind the remember-me checkbox and pass the flag to the service; stray debug markup showing the JWT was removed. These changes keep token state consistent and limit direct localStorage access across the app.