### PR TITLE
Use AuthService token in redirection guard

### DIFF
--- a/client/social-network/src/app/guards/redirection-guard.ts
+++ b/client/social-network/src/app/guards/redirection-guard.ts
@@ -1,11 +1,13 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
+import { AuthService } from '../services/auth';
 
 export const redirectionGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
+  const authService = inject(AuthService);
 
-  // Verificamos si existe el token JWT en localStorage
-  const token = localStorage.getItem('jwt');
+  // Obtenemos el token JWT de authService
+  const token = authService.getToken();
 
   if (token) {
     // Si hay token, permitimos acceso

--- a/client/social-network/src/app/guards/redirection-guard.ts
+++ b/client/social-network/src/app/guards/redirection-guard.ts
@@ -6,11 +6,8 @@ export const redirectionGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
   const authService = inject(AuthService);
 
-  // Obtenemos el token JWT de authService
-  const token = authService.getToken();
-
-  if (token) {
-    // Si hay token, permitimos acceso
+  // Verificamos si existe el token JWT en el servicio o en localStorage
+  if (authService.jwt) {
     return true;
   } else {
     // Si no hay token, redirigimos a login con queryParam para ir a feed después

--- a/client/social-network/src/app/services/auth.ts
+++ b/client/social-network/src/app/services/auth.ts
@@ -23,4 +23,9 @@ export class AuthService {
 
     return result;
   }
+
+  // Método para obtener el token JWT actual
+  getToken(): string | null {
+    return this.api.jwt;
+  }
 }


### PR DESCRIPTION
Inject AuthService into the redirection guard and replace direct localStorage access with authService.getToken(). Adds getToken() to AuthService (returns this.api.jwt) to centralize JWT retrieval and avoid direct localStorage reads.