### PR TITLE
Register form binding and nullable AvatarPath

### DIFF
--- a/client/social-network/src/app/models/add-user-dto.ts
+++ b/client/social-network/src/app/models/add-user-dto.ts
@@ -1,0 +1,10 @@
+// Modelo para el registro de usuario (AddUserDto)
+export interface AddUserDto {
+    email: string;
+    nickname: string;
+    avatarPath: string | null;
+    name: string;
+    surname1: string;
+    surname2: string | null;
+    password: string;
+}

--- a/client/social-network/src/app/pages/register/register.html
+++ b/client/social-network/src/app/pages/register/register.html
@@ -1,5 +1,10 @@
 <div class="big-container">
-    <form>
+    <form (submit)="submit()">
+        @if (errorMessage()) {
+            <div style="color: red; margin-bottom: 1em; text-align: center;">
+                {{ errorMessage() }}
+            </div>
+        }
         <div class="container">
             <div class="container-header">
                 <h1>¡Bienvenido a TechIt!</h1>
@@ -8,31 +13,31 @@
             <div class="div-form">
                 <div class="div-input">
                     <span>Nombre<span class="required">*</span></span>
-                    <input type="text" id="name" required>
+                    <input type="text" id="name" required [(ngModel)]="name" name="name">
                 </div>
                 <div class="div-input">
                     <span>Primer apellido<span class="required">*</span></span>
-                    <input type="text" id="surname1" required>
+                    <input type="text" id="surname1" required [(ngModel)]="surname1" name="surname1">
                 </div>
                 <div class="div-input">
                     <span>Segundo apellido</span>
-                    <input type="text" id="surname2">
+                    <input type="text" id="surname2" [(ngModel)]="surname2" name="surname2">
                 </div>
                 <div class="div-input">
                     <span>Nickname<span class="required">*</span></span>
-                    <input type="text" id="nickname" required>
+                    <input type="text" id="nickname" required [(ngModel)]="nickname" name="nickname">
                 </div>
                 <div class="div-input">
                     <span>Correo electrónico<span class="required">*</span></span>
-                    <input type="text" id="input-email" required>
+                    <input type="text" id="input-email" required [(ngModel)]="email" name="email">
                 </div>
                 <div class="div-input">
                     <span>Contraseña <span class="required">*</span></span>
-                    <input type="password" id="input-password" required>
+                    <input type="password" id="input-password" required [(ngModel)]="password" name="password">
                 </div>
                 <div class="div-input">
                     <span>Confirmar contraseña <span class="required">*</span></span>
-                    <input type="password" id="input-password" required>
+                    <input type="password" id="input-password-confirm" required [(ngModel)]="confirmPassword" name="confirmPassword">
                 </div>
                 <div class="div-input">
                     <input class="btn" type="submit" value="Registrarse">

--- a/client/social-network/src/app/pages/register/register.ts
+++ b/client/social-network/src/app/pages/register/register.ts
@@ -1,18 +1,61 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { RouterLink, Router } from '@angular/router';
+import { AddUserDto } from '../../models/add-user-dto';
+import { ApiService } from '../../services/api';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-register',
-  imports: [RouterLink],
+  imports: [RouterLink, FormsModule],
   templateUrl: './register.html',
   styleUrl: './register.css',
 })
 export class Register implements OnInit, OnDestroy {
+  name: string = '';
+  surname1: string = '';
+  surname2: string = '';
+  nickname: string = '';
+  email: string = '';
+  password: string = '';
+  confirmPassword: string = '';
+  avatarPath: string | null = null;
+  errorMessage = signal('');
+
+  constructor(private api: ApiService, private router: Router) {}
+
   ngOnInit() {
     document.body.classList.add('login-background');
   }
 
   ngOnDestroy() {
     document.body.classList.remove('login-background');
+  }
+
+  async submit() {
+    // Validación básica de contraseñas
+    this.errorMessage.set('');
+    if (this.password !== this.confirmPassword) {
+      this.errorMessage.set('Las contraseñas no coinciden.');
+      return;
+    }
+
+
+    // Enviar propiedades con mayúscula inicial para .NET
+    const user: any = {
+      Name: this.name,
+      Surname1: this.surname1,
+      Nickname: this.nickname,
+      Email: this.email,
+      Password: this.password
+    };
+    if (this.surname2) user.Surname2 = this.surname2;
+    if (this.avatarPath) user.AvatarPath = this.avatarPath;
+
+    const result = await this.api.post<AddUserDto>('users', user);
+    if (result.success) {
+      this.router.navigate(['/login']);
+    } else {
+      this.errorMessage.set('Error al registrar usuario: ' + result.error);
+    }
   }
 }

--- a/server/SocialNetwork/SocialNetwork/Controllers/UsersController.cs
+++ b/server/SocialNetwork/SocialNetwork/Controllers/UsersController.cs
@@ -44,7 +44,7 @@ public class UsersController : ControllerBase {
             Password = user.Password,
             Role = user.Role,
             Surname2 = user.Surname2,
-            AvatarPath = user.AvatarPath!,
+            AvatarPath = user.AvatarPath,
             Description = user.Description
         });
         return getAllUsersDto;

--- a/server/SocialNetwork/SocialNetwork/Models/DataBase/Entities/User.cs
+++ b/server/SocialNetwork/SocialNetwork/Models/DataBase/Entities/User.cs
@@ -13,7 +13,7 @@ public class User {
     public required string Password { get; set; }
     public string Role { get; set; } = "user";
     public string? Surname2 { get; set; }
-    public string AvatarPath { get; set; } = "/defaultAvatar.png"; //??
+    public string? AvatarPath { get; set; } = null;
     public string? Description { get; set; }
 
     // Estas colecciones representan las relaciones con otras entidades

--- a/server/SocialNetwork/SocialNetwork/Models/Dtos/Users/AddUserDto.cs
+++ b/server/SocialNetwork/SocialNetwork/Models/Dtos/Users/AddUserDto.cs
@@ -2,7 +2,7 @@
     public class AddUserDto {
         public required string Email { get; set; } 
         public required string Nickname { get; set; } //hace falta indicar que es requerido en los que la entidad son required?
-        public string AvatarPath { get; set; } = "/defaultAvatar.png";
+        public string? AvatarPath { get; set; } = null;
         public required string Name { get; set; }
         public required string Surname1 { get; set; }
         public string? Surname2 { get; set; } = null;


### PR DESCRIPTION
Bind and submit the client registration form and make AvatarPath optional on the server.

Client: add AddUserDto model, enable FormsModule and ngModel bindings for form fields, show error messages, add basic password confirmation validation, build PascalCase payload for .NET, and call ApiService to create the user then navigate to login. 

Server: make AvatarPath nullable in User entity and AddUserDto, and remove the null-forgiving operator in UsersController when mapping AvatarPath.