### PR TITLE
Perfil de otro usuario

### DIFF
--- a/client/social-network/src/app/app.routes.ts
+++ b/client/social-network/src/app/app.routes.ts
@@ -15,6 +15,7 @@ export const routes: Routes = [
     { path: 'feed', component: Feed },
     { path: 'login', component: Login },
     { path: 'profile', component: Profile, canActivate: [redirectionGuard] },
+    { path: 'profile/:id', component: Profile },
     { path: 'landing', component: Landing },
     { path: 'register', component: Register },
     { path: '', redirectTo: 'landing', pathMatch: 'full' }

--- a/client/social-network/src/app/pages/feed/feed.css
+++ b/client/social-network/src/app/pages/feed/feed.css
@@ -35,6 +35,13 @@
     gap: 10px;
 }
 
+.user-link {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    text-decoration: none;
+}
+
 span {
     font-size: 12px;
     color: gray;

--- a/client/social-network/src/app/pages/feed/feed.html
+++ b/client/social-network/src/app/pages/feed/feed.html
@@ -1,8 +1,10 @@
 @for (post of posts(); track $index) {
     <div class="post">
         <div class="post-header">
-            <img [src]="post.avatarPath ? post.avatarPath : '/assets/images/avatar-default.png'" alt="Avatar" class="avatar">
-            <span class="nickname">{{post.nickname}}</span>
+            <a class="user-link" [routerLink]="['/profile', post.userId]">
+                <img [src]="post.avatarPath ? post.avatarPath : '/assets/images/avatar-default.png'" alt="Avatar" class="avatar">
+                <span class="nickname">{{post.nickname}}</span>
+            </a>
         </div>
         <h3>{{post.title}}</h3>
         <p>{{post.description}}</p>

--- a/client/social-network/src/app/pages/feed/feed.ts
+++ b/client/social-network/src/app/pages/feed/feed.ts
@@ -5,10 +5,11 @@ import { DatePipe } from '@angular/common';
 import { AuthService } from '../../services/auth';
 import { jwtDecode } from 'jwt-decode';
 import { CreatePostBtn } from '../../components/create-post-btn/create-post-btn';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-feed',
-  imports: [DatePipe, CreatePostBtn],
+  imports: [DatePipe, CreatePostBtn, RouterModule],
   templateUrl: './feed.html',
   styleUrl: './feed.css',
 })

--- a/client/social-network/src/app/pages/profile/profile.html
+++ b/client/social-network/src/app/pages/profile/profile.html
@@ -1,4 +1,11 @@
 <div class="container">
+	@if (loading()) {
+		<p>Cargando perfil...</p>
+	} @else {
+		@if (errorMessage()) {
+			<p>{{ errorMessage() }}</p>
+		}
+
 	<div class="profile-header">
 		<img [src]="profileImage()" alt="Avatar" class="avatar">
         <div class="biography">
@@ -10,16 +17,19 @@
 	</div>
 	<div class="profile-stats">
 		<div class="stat">
-			<span class="stat-number">123</span>
+			<span class="stat-number">{{ followers() }}</span>
 			<span class="stat-label">Seguidores</span>
 		</div>
 		<div class="stat">
-			<span class="stat-number">456</span>
+			<span class="stat-number">{{ followeds() }}</span>
 			<span class="stat-label">Seguidos</span>
 		</div>
 	</div>
     <!--Mostrar las publicaciones del usuario-->
-	<button class="logout" (click)="logout()">Cerrar sesión</button>
+	@if (isOwnProfile()) {
+		<button class="logout" (click)="logout()">Cerrar sesión</button>
+	}
+	}
 </div>
 
 <app-create-post-btn />

--- a/client/social-network/src/app/pages/profile/profile.ts
+++ b/client/social-network/src/app/pages/profile/profile.ts
@@ -1,7 +1,8 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { AuthService } from '../../services/auth';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { CreatePostBtn } from '../../components/create-post-btn/create-post-btn';
+import { ApiService } from '../../services/api';
 
 @Component({
   selector: 'app-profile',
@@ -9,13 +10,64 @@ import { CreatePostBtn } from '../../components/create-post-btn/create-post-btn'
   templateUrl: './profile.html',
   styleUrl: './profile.css',
 })
-export class Profile {
+export class Profile implements OnInit {
   private readonly auth = inject(AuthService);
   private readonly router = inject(Router);
-  
-  protected readonly nickname = this.auth.nickname;
-  protected readonly profileImage = this.auth.profileImage;
-  protected readonly biography = this.auth.biography;
+  private readonly route = inject(ActivatedRoute);
+  private readonly api = inject(ApiService);
+
+  protected readonly nickname = signal('Usuario');
+  protected readonly profileImage = signal('/assets/images/avatar-default.png');
+  protected readonly biography = signal('');
+  protected readonly followers = signal(0);
+  protected readonly followeds = signal(0);
+  protected readonly isOwnProfile = signal(true);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal('');
+
+  async ngOnInit(): Promise<void> {
+    const routeId = this.route.snapshot.paramMap.get('id');
+    const requestedUserId = routeId ? Number(routeId) : null;
+    const currentUserId = this.auth.currentUserId();
+
+    if (!requestedUserId || Number.isNaN(requestedUserId) || requestedUserId === currentUserId) {
+      this.loadOwnProfileFromJwt();
+      return;
+    }
+
+    this.isOwnProfile.set(false);
+    await this.loadExternalProfile(requestedUserId);
+  }
+
+  private loadOwnProfileFromJwt(): void {
+    this.isOwnProfile.set(true);
+    this.nickname.set(this.auth.nickname());
+    this.profileImage.set(this.auth.profileImage());
+    this.biography.set(this.auth.biography());
+    this.followers.set(0);
+    this.followeds.set(0);
+    this.errorMessage.set('');
+    this.loading.set(false);
+  }
+
+  private async loadExternalProfile(userId: number): Promise<void> {
+    this.loading.set(true);
+    this.errorMessage.set('');
+
+    try {
+      const profile = await this.api.getUserProfileById(userId);
+
+      this.nickname.set(profile?.nickname ?? 'Usuario');
+      this.profileImage.set(profile?.avatarPath || '/assets/images/avatar-default.png');
+      this.biography.set(profile?.biography ?? '');
+      this.followers.set(profile?.followers ?? profile?.followersCount ?? 0);
+      this.followeds.set(profile?.followeds ?? profile?.followedsCount ?? 0);
+    } catch {
+      this.errorMessage.set('No se pudo cargar el perfil del usuario.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
 
   logout() {
     this.auth.jwt = null;

--- a/client/social-network/src/app/services/api.ts
+++ b/client/social-network/src/app/services/api.ts
@@ -107,4 +107,13 @@ export class ApiService {
       throw err; // cualquier otro error
     }
   }
+
+  // Obtiene el perfil público de un usuario por su id
+  async getUserProfileById(userId: number): Promise<any> {
+    const request = this.http.get<any>(`${this.BASE_URL}users/${userId}/profile`, {
+      headers: this.getHeaders()
+    });
+    const response = await lastValueFrom(request);
+    return response;
+  }
 }


### PR DESCRIPTION
Se ha añadido lo siguiente:
- Se ha añadido en el apiService el endpoint para recoger los datos del perfil de usuario.
- Se están utilizando path params para navegar al perfil de uno u otro usuario, por ejemplo /profile/1.
- Se espera que el endpoint sea un GET ["{id}/profile"].
- Si el id de la ruta coincide con el id del usuario logueado, entonces los datos no se recogen del endpoint, sino del jwt para no saturar innecesariamente al servidor.
- Un usuario anónimo puede ver los perfiles de cualquier usuario, ya que esta información es pública.
- Cuando se hace click a la imagen o al nickname de un usuario en una publicación, navegará a su perfil.