### PR TITLE
Use inject() for dependency injection

### DIFF
--- a/client/social-network/src/app/components/create-post-btn/create-post-btn.ts
+++ b/client/social-network/src/app/components/create-post-btn/create-post-btn.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { CreatePostModal } from '../create-post-modal/create-post-modal';
 import { ApiService } from '../../services/api';
 import { AuthService } from '../../services/auth';
@@ -13,11 +13,8 @@ import { AddPostDto } from '../../models/add-post-dto';
 })
 export class CreatePostBtn {
   protected readonly isModalOpen = signal(false);
-
-  constructor(
-    private apiService: ApiService,
-    private authService: AuthService
-  ) { }
+  private readonly apiService = inject(ApiService);
+  private readonly authService = inject(AuthService);
 
   openModal() {
     this.isModalOpen.set(true);

--- a/client/social-network/src/app/pages/login/login.ts
+++ b/client/social-network/src/app/pages/login/login.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { RouterLink, Router, ActivatedRoute } from "@angular/router";
 import { AuthRequest } from '../../models/auth-request';
 import { AuthService } from '../../services/auth';
@@ -18,12 +18,9 @@ export class Login implements OnInit, OnDestroy {
   rememberMeChecked: boolean = false;
 
   errorMessage = signal('');
-
-  constructor(
-    private authService: AuthService,
-    private router: Router,
-    private route: ActivatedRoute
-  ) {}
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   // Método del submit del formulario de login
   async submit() {

--- a/client/social-network/src/app/pages/register/register.ts
+++ b/client/social-network/src/app/pages/register/register.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { RouterLink, Router } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -16,12 +16,11 @@ export class Register implements OnInit, OnDestroy {
 
   registerForm: FormGroup;
   errorMessage = signal('');
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
 
-  constructor(
-    private fb: FormBuilder,
-    private authService: AuthService,
-    private router: Router
-  ) {
+  constructor() {
 
     this.registerForm = this.fb.group({
       name: ['', [Validators.required, Validators.minLength(2)]],

--- a/client/social-network/src/app/services/auth.ts
+++ b/client/social-network/src/app/services/auth.ts
@@ -1,4 +1,4 @@
-import { computed, Injectable, signal } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 import { jwtDecode } from 'jwt-decode';
 import { AuthRequest } from '../models/auth-request';
 import { AuthResponse } from '../models/auth-response';
@@ -19,6 +19,8 @@ type JwtPayload = {
   providedIn: 'root',
 })
 export class AuthService {
+  private readonly api = inject(ApiService);
+
   private readonly jwtSignal = signal<string | null>(null);
 
   private readonly decodedPayload = computed<JwtPayload | null>(() => {
@@ -83,7 +85,7 @@ export class AuthService {
     this.api.jwt = value;
   }
 
-  constructor(private api: ApiService) {
+  constructor() {
     const jwt = localStorage.getItem('jwt');
     if (jwt) {
       this.setJwt(jwt);


### PR DESCRIPTION
Replace constructor-based DI with Angular's inject() in several files. Updated imports to include inject and removed constructor parameters in CreatePostBtn, Login, and Register components; FormBuilder, AuthService, Router, and ActivatedRoute are now injected via readonly fields. AuthService now injects ApiService via a private readonly api field and has a parameterless constructor. Changes keep behavior the same while simplifying DI and enabling cleaner standalone/component patterns.