### PR TITLE
Add follow/unfollow support to profile

### DIFF
--- a/client/social-network/src/app/models/following-dto.ts
+++ b/client/social-network/src/app/models/following-dto.ts
@@ -1,0 +1,4 @@
+export interface FollowingDto {
+  followerId: number;
+  followedId: number;
+}

--- a/client/social-network/src/app/pages/about/about.html
+++ b/client/social-network/src/app/pages/about/about.html
@@ -44,7 +44,7 @@
             </div>
             <div class="team-member">
                 <div class="member-role">Desarrollador</div>
-                <h3>Jesús Fuentes Trigeros</h3>
+                <h3>Jesús Felipe Fuentes Trigueros</h3>
             </div>
             <div class="team-member">
                 <div class="member-role">Desarrollador</div>

--- a/client/social-network/src/app/pages/profile/profile.css
+++ b/client/social-network/src/app/pages/profile/profile.css
@@ -65,6 +65,34 @@
 	color: var(--secondary-color-light);
 }
 
+.follow-actions {
+	margin-top: 18px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+}
+
+.follow-btn {
+	margin-top: 0;
+	min-width: 170px;
+	background: var(--secondary-color);
+}
+
+.follow-btn:hover:not(:disabled) {
+	background: var(--secondary-color-dark);
+}
+
+.follow-btn:disabled {
+	opacity: 0.65;
+	cursor: wait;
+}
+
+.follow-error {
+	margin: 0;
+	color: #b71c1c;
+}
+
 p {
     max-width: 50ch;
     color: var(--primary-color);
@@ -145,6 +173,17 @@ p {
 	gap: 12px;
 	margin-top: 14px;
 	color: var(--primary-color);
+}
+
+.posts-page-current {
+	font-weight: 400;
+	color: var(--secondary-color);
+}
+
+.posts-page-current-top {
+	display: block;
+	text-align: left;
+	margin-bottom: 10px;
 }
 
 .posts-page-btn {

--- a/client/social-network/src/app/pages/profile/profile.html
+++ b/client/social-network/src/app/pages/profile/profile.html
@@ -42,6 +42,27 @@
 			</div>
 		</div>
 
+		@if (!isOwnProfile()) {
+			<div class="follow-actions">
+				<button
+					type="button"
+					class="follow-btn"
+					(click)="onFollowButtonClick()"
+					[disabled]="followActionLoading()"
+				>
+					@if (followActionLoading()) {
+						Actualizando...
+					} @else {
+						{{ isFollowingProfile() ? 'Dejar de seguir' : 'Seguir' }}
+					}
+				</button>
+
+				@if (followActionError()) {
+					<p class="follow-error">{{ followActionError() }}</p>
+				}
+			</div>
+		}
+
 		@if (isOwnProfile()) {
 			<button class="logout" (click)="logout()">Cerrar sesión</button>
 			<div class="avatar-actions">
@@ -61,6 +82,10 @@
 			} @else if (userPosts().length === 0) {
 				<p class="posts-status">Este usuario aun no tiene publicaciones.</p>
 			} @else {
+				<span class="posts-page-current posts-page-current-top">
+					Pagina {{ currentPostsPage() }} / {{ totalPostsPages() }}
+				</span>
+
 				<div class="posts-list">
 					@for (post of paginatedUserPosts(); track post.id) {
 						<article class="profile-post">

--- a/client/social-network/src/app/pages/profile/profile.ts
+++ b/client/social-network/src/app/pages/profile/profile.ts
@@ -32,6 +32,9 @@ export class Profile implements OnInit {
   protected readonly followers = signal(0);
   protected readonly followeds = signal(0);
   protected readonly isOwnProfile = signal(true);
+  protected readonly isFollowingProfile = signal(false);
+  protected readonly followActionLoading = signal(false);
+  protected readonly followActionError = signal('');
   protected readonly loading = signal(true);
   protected readonly errorMessage = signal('');
   protected readonly usersModalOpen = signal(false);
@@ -78,8 +81,12 @@ export class Profile implements OnInit {
     const requestedUserId = routeId ? Number(routeId) : null;
     const currentUserId = this.auth.currentUserId();
 
+    this.followActionLoading.set(false);
+    this.followActionError.set('');
+
     if (!requestedUserId || Number.isNaN(requestedUserId)) {
       this.isOwnProfile.set(true);
+      this.isFollowingProfile.set(false);
       this.profileUserId = currentUserId;
 
       if (currentUserId) {
@@ -102,13 +109,88 @@ export class Profile implements OnInit {
 
     if (requestedUserId === currentUserId) {
       this.profileUserId = currentUserId;
+      this.isFollowingProfile.set(false);
       await this.router.navigate(['/profile']);
       return;
     }
 
     this.profileUserId = requestedUserId;
     this.isOwnProfile.set(false);
-    await this.loadProfile(requestedUserId);
+    this.isFollowingProfile.set(false);
+
+    await Promise.allSettled([
+      this.loadProfile(requestedUserId),
+      this.loadFollowStatus(requestedUserId, currentUserId),
+    ]);
+  }
+
+  private async loadFollowStatus(
+    profileUserId: number,
+    currentUserId: number | null
+  ): Promise<void> {
+    if (!currentUserId || currentUserId === profileUserId) {
+      this.isFollowingProfile.set(false);
+      return;
+    }
+
+    try {
+      const followedUsers = await this.api.getFollowedUsers(currentUserId);
+
+      this.isFollowingProfile.set(
+        followedUsers.some((user) => user.id === profileUserId)
+      );
+    } catch {
+      this.isFollowingProfile.set(false);
+    }
+  }
+
+  protected async onFollowButtonClick(): Promise<void> {
+    const followedId = this.profileUserId;
+
+    if (!followedId || this.isOwnProfile()) {
+      return;
+    }
+
+    const followerId = this.auth.currentUserId();
+
+    if (!followerId || !this.auth.jwt) {
+      await this.router.navigate(['/login'], {
+        queryParams: { redirectTo: this.router.url },
+      });
+      return;
+    }
+
+    if (followerId === followedId) {
+      return;
+    }
+
+    this.followActionLoading.set(true);
+    this.followActionError.set('');
+
+    try {
+      if (this.isFollowingProfile()) {
+        await this.api.unfollowUser(followerId, followedId);
+        this.isFollowingProfile.set(false);
+        this.followers.update((count) => Math.max(0, count - 1));
+      } else {
+        await this.api.followUser({ followerId, followedId });
+        this.isFollowingProfile.set(true);
+        this.followers.update((count) => count + 1);
+      }
+    } catch (err: any) {
+      const backendError =
+        typeof err?.error === 'string'
+          ? err.error
+          : err?.error?.error ||
+            err?.error?.message ||
+            err?.message;
+
+      this.followActionError.set(
+        backendError || 'No se pudo actualizar el seguimiento.'
+      );
+    } finally {
+      this.followActionLoading.set(false);
+    }
   }
 
   private async loadProfile(userId: number): Promise<void> {

--- a/client/social-network/src/app/services/api.ts
+++ b/client/social-network/src/app/services/api.ts
@@ -3,6 +3,7 @@ import { inject, Injectable } from '@angular/core';
 import { lastValueFrom } from 'rxjs';
 import { GetUserDto } from '../models/get-user-dto';
 import { Post } from '../models/post';
+import { FollowingDto } from '../models/following-dto';
 
 @Injectable({
   providedIn: 'root',
@@ -25,6 +26,13 @@ export class ApiService {
   async get<T>(path: string): Promise<T> {
     return await lastValueFrom(
       this.http.get<T>(`${this.BASE_URL}${path}`)
+    );
+  }
+
+  // Metodo para hacer peticiones DELETE a la API
+  async delete(path: string, body?: any): Promise<void> {
+    await lastValueFrom(
+      this.http.delete<void>(`${this.BASE_URL}${path}`, { body })
     );
   }
 
@@ -78,6 +86,33 @@ export class ApiService {
   // Obtiene la lista de seguidores de un usuario
   async getFollowerUsers(userId: number): Promise<GetUserDto[]> {
     return await this.get<GetUserDto[]>(`users/Followers?userId=${userId}`);
+  }
+
+  async followUser(dto: FollowingDto): Promise<FollowingDto> {
+    try {
+      return await this.post<FollowingDto>('following', dto);
+    } catch (err: any) {
+      if (err?.status === 404) {
+        return await this.post<FollowingDto>('followings', dto);
+      }
+
+      throw err;
+    }
+  }
+
+  async unfollowUser(followerId: number, followedId: number): Promise<void> {
+    const body: FollowingDto = { followerId, followedId };
+
+    try {
+      await this.delete('following', body);
+    } catch (err: any) {
+      if (err?.status === 404) {
+        await this.delete('followings', body);
+        return;
+      }
+
+      throw err;
+    }
   }
 
   async uploadAvatar(file: File): Promise<{ avatarUrl: string }> {


### PR DESCRIPTION
Introduce follow/unfollow functionality across the client:
- Add FollowingDto model, API helpers (delete, followUser, unfollowUser) with 404 fallbacks to alternate endpoints, and profile UI/logic.
- Profile changes include a follow button, loading/error states, follow status load (loadFollowStatus), onFollowButtonClick handler (auth redirect, optimistic follower count updates)
- New CSS utilities for follow actions and current posts page indicator.

- Also fix a team member name in the about page.