### PR TITLE
Add admin user management UI and logic

### DIFF
--- a/client/social-network/src/app/pages/admin/admin.css
+++ b/client/social-network/src/app/pages/admin/admin.css
@@ -1,0 +1,375 @@
+:host {
+	display: block;
+}
+
+.admin-panel {
+	width: min(1120px, 95%);
+	margin: 0 auto;
+	padding: 30px clamp(16px, 3vw, 34px);
+	border-radius: 20px;
+	border: 1px solid var(--secondary-color-transparent-border);
+	box-shadow: 0 16px 34px rgba(19, 32, 58, 0.1);
+	background: linear-gradient(180deg, #ffffff 0%, #fff8f1 100%);
+}
+
+.admin-header {
+	margin-bottom: 24px;
+}
+
+.admin-tag {
+	margin: 0;
+	font-size: 0.8rem;
+	text-transform: uppercase;
+	letter-spacing: 1.4px;
+	font-weight: 700;
+	color: var(--secondary-color-dark);
+}
+
+.admin-header h1 {
+	margin: 8px 0 10px;
+	color: var(--primary-color);
+	font-size: clamp(1.5rem, 2vw, 2rem);
+}
+
+.admin-subtitle {
+	margin: 0;
+	max-width: 760px;
+	color: var(--text-muted);
+	line-height: 1.55;
+}
+
+.admin-kpis {
+	margin-top: 18px;
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 12px;
+}
+
+.kpi-card {
+	padding: 14px;
+	border-radius: 12px;
+	border: 1px solid var(--secondary-color-transparent-border);
+	background: linear-gradient(180deg, #ffffff 0%, #fff2e9 100%);
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.kpi-number {
+	font-size: 1.32rem;
+	font-weight: 700;
+	color: var(--secondary-color-dark);
+}
+
+.kpi-label {
+	color: var(--text-muted);
+	font-size: 0.9rem;
+}
+
+.admin-feedback {
+	margin: 0 0 18px;
+	border-radius: 10px;
+	border: 1px solid var(--secondary-color-transparent-border);
+	background: var(--secondary-color-transparent-light);
+	color: var(--primary-color);
+	padding: 11px 14px;
+	font-weight: 500;
+}
+
+.admin-empty-state {
+	margin: 12px 0 4px;
+	border: 1px dashed var(--secondary-color-transparent-border);
+	background: var(--surface-highlight);
+	border-radius: 14px;
+	padding: 20px;
+	text-align: center;
+}
+
+.admin-empty-state h2 {
+	margin: 0 0 8px;
+	color: var(--secondary-color-dark);
+	font-size: 1.2rem;
+}
+
+.admin-empty-state p {
+	margin: 0;
+	color: var(--text-muted);
+}
+
+.users-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.user-card {
+	border-radius: 14px;
+	border: 1px solid var(--secondary-color-transparent-border);
+	background: linear-gradient(180deg, #ffffff 0%, #fff9f4 100%);
+	box-shadow: 0 10px 20px rgba(19, 32, 58, 0.08);
+	padding: 16px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 16px;
+	position: relative;
+	overflow: hidden;
+}
+
+.user-card::before {
+	content: '';
+	position: absolute;
+	inset: 0 auto 0 0;
+	width: 6px;
+	background: linear-gradient(180deg, var(--secondary-color) 0%, #ff8a60 100%);
+}
+
+.user-card-main {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	min-width: 0;
+}
+
+.user-avatar {
+	width: 42px;
+	height: 42px;
+	border-radius: 50%;
+	object-fit: cover;
+	border: 2px solid var(--secondary-color-transparent-border);
+	background: var(--secondary-color-transparent-light);
+	flex-shrink: 0;
+}
+
+.user-data {
+	min-width: 0;
+}
+
+.user-data h2 {
+	margin: 0;
+	color: var(--primary-color);
+	font-size: 1.06rem;
+}
+
+.user-data p {
+	margin: 4px 0 0;
+	color: var(--text-muted);
+	overflow-wrap: anywhere;
+}
+
+.user-actions {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	flex-wrap: wrap;
+	justify-content: flex-end;
+}
+
+.role-control {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.role-control label {
+	color: var(--text-main);
+	font-size: 0.82rem;
+	font-weight: 600;
+}
+
+.role-control select {
+	min-width: 120px;
+	border-radius: 9px;
+	border: 1px solid var(--border-soft);
+	background: #fff;
+	color: var(--text-main);
+	padding: 8px 10px;
+	font-weight: 600;
+}
+
+.delete-user-btn,
+.close-modal-btn,
+.action-btn {
+	border: none;
+	cursor: pointer;
+	transition: transform 0.2s ease, background-color 0.2s ease, opacity 0.2s ease;
+}
+
+.delete-user-btn {
+	padding: 10px 14px;
+	border-radius: 10px;
+	font-size: 0.88rem;
+	font-weight: 700;
+	color: #fff;
+	background: #b42318;
+}
+
+.delete-user-btn:hover {
+	background: #9f2016;
+	transform: translateY(-1px);
+}
+
+.modal-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(19, 32, 58, 0.36);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 20px;
+	z-index: 130;
+}
+
+.delete-modal {
+	width: min(92vw, 560px);
+	border-radius: 14px;
+	border: 1px solid var(--border-soft);
+	background: #fff;
+	box-shadow: 0 18px 36px rgba(19, 32, 58, 0.24);
+	padding: 16px;
+}
+
+.delete-modal-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	margin-bottom: 10px;
+}
+
+.delete-modal-header h3 {
+	margin: 0;
+	color: var(--primary-color);
+	font-size: 1.16rem;
+}
+
+.close-modal-btn {
+	width: 34px;
+	height: 34px;
+	border-radius: 8px;
+	background: var(--surface-highlight);
+	color: var(--secondary-color-dark);
+	font-weight: 700;
+	font-size: 1rem;
+	line-height: 1;
+}
+
+.close-modal-btn:hover {
+	background: var(--secondary-color-transparent-medium);
+}
+
+.delete-description {
+	margin: 0 0 8px;
+	color: var(--text-main);
+	line-height: 1.5;
+}
+
+.delete-label {
+	display: block;
+	margin-top: 10px;
+	margin-bottom: 6px;
+	color: var(--text-main);
+	font-weight: 600;
+	font-size: 0.9rem;
+}
+
+.delete-input {
+	width: 100%;
+	box-sizing: border-box;
+	border-radius: 10px;
+	border: 1px solid var(--border-soft);
+	padding: 10px 12px;
+	font-size: 0.95rem;
+	color: var(--text-main);
+	background: #fff;
+}
+
+.delete-input:focus,
+.role-control select:focus {
+	outline: none;
+	border-color: var(--secondary-color);
+	box-shadow: 0 0 0 3px var(--secondary-color-transparent-light);
+}
+
+.delete-warning {
+	margin: 8px 0 0;
+	color: var(--alert-color);
+	font-size: 0.88rem;
+	font-weight: 600;
+}
+
+.delete-actions {
+	margin-top: 14px;
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+.action-btn {
+	border-radius: 10px;
+	padding: 9px 14px;
+	font-weight: 700;
+	font-size: 0.9rem;
+}
+
+.secondary-btn {
+	color: var(--primary-color);
+	background: #eef2f8;
+}
+
+.secondary-btn:hover {
+	background: #e3e9f2;
+}
+
+.danger-btn {
+	color: #fff;
+	background: #b42318;
+}
+
+.danger-btn:hover:not(:disabled) {
+	background: #9f2016;
+}
+
+.danger-btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+@media (max-width: 900px) {
+	.admin-kpis {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.user-card {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.user-actions {
+		justify-content: flex-start;
+	}
+}
+
+@media (max-width: 640px) {
+	.admin-panel {
+		padding: 22px 14px;
+	}
+
+	.admin-kpis {
+		grid-template-columns: 1fr;
+	}
+
+	.user-card-main {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 10px;
+	}
+
+	.delete-user-btn {
+		width: 100%;
+	}
+}

--- a/client/social-network/src/app/pages/admin/admin.html
+++ b/client/social-network/src/app/pages/admin/admin.html
@@ -1,1 +1,142 @@
-<p>admin works!</p>
+<section class="admin-panel">
+	<header class="admin-header">
+		<p class="admin-tag">Panel de administracion</p>
+		<h1>Gestion de usuarios</h1>
+		<p class="admin-subtitle">
+			Plantilla visual temporal. Aqui se podrá gestionar usuarios en cuanto esten aplicados los endpoints.
+		</p>
+
+		<div class="admin-kpis">
+			<article class="kpi-card">
+				<span class="kpi-number">{{ totalUsers() }}</span>
+				<span class="kpi-label">Usuarios totales</span>
+			</article>
+
+			<article class="kpi-card">
+				<span class="kpi-number">{{ totalAdmins() }}</span>
+				<span class="kpi-label">Con rol admin</span>
+			</article>
+
+			<article class="kpi-card">
+				<span class="kpi-number">{{ totalStandardUsers() }}</span>
+				<span class="kpi-label">Con rol user</span>
+			</article>
+		</div>
+	</header>
+
+	@if (actionMessage()) {
+		<p class="admin-feedback">{{ actionMessage() }}</p>
+	}
+
+	@if (users().length === 0) {
+		<div class="admin-empty-state">
+			<h2>No hay usuarios para mostrar</h2>
+			<p>Cuando lleguen datos reales desde backend apareceran aqui.</p>
+		</div>
+	} @else {
+		<ul class="users-list">
+			@for (user of users(); track user.id) {
+				<li class="user-card">
+					<div class="user-card-main">
+						<img
+							[src]="user.avatarPath ? user.avatarPath : '/assets/images/avatar-default.png'"
+							[alt]="'Avatar de ' + user.nickname"
+							class="user-avatar"
+						>
+
+						<div class="user-data">
+							<h2>{{ user.nickname }}</h2>
+							<p>{{ user.email }}</p>
+						</div>
+					</div>
+
+					<div class="user-actions">
+						<div class="role-control">
+							<label [attr.for]="'role-select-' + user.id">Rol</label>
+							<select
+								[id]="'role-select-' + user.id"
+								[value]="user.role"
+								(change)="onRoleChange(user.id, $event)"
+							>
+								<option value="user">user</option>
+								<option value="admin">admin</option>
+							</select>
+						</div>
+
+						<button
+							type="button"
+							class="delete-user-btn"
+							(click)="openDeleteModal(user)"
+						>
+							Borrar usuario
+						</button>
+					</div>
+				</li>
+			}
+		</ul>
+	}
+</section>
+
+@if (selectedUserForDeletion(); as userToDelete) {
+	<div class="modal-overlay" (click)="onModalOverlayClick($event)">
+		<section
+			class="delete-modal"
+			role="dialog"
+			aria-modal="true"
+			[attr.aria-labelledby]="'delete-title-' + userToDelete.id"
+		>
+			<header class="delete-modal-header">
+				<h3 [id]="'delete-title-' + userToDelete.id">Confirmar borrado de usuario</h3>
+
+				<button
+					type="button"
+					class="close-modal-btn"
+					aria-label="Cerrar modal"
+					(click)="closeDeleteModal()"
+				>
+					x
+				</button>
+			</header>
+
+			<p class="delete-description">
+				Estas a punto de borrar a <strong>{{ userToDelete.nickname }}</strong>.
+			</p>
+
+			<p class="delete-description">
+				Para confirmar, escribe exactamente su nickname.
+			</p>
+
+			<label class="delete-label" [attr.for]="'confirm-delete-' + userToDelete.id">
+				Nickname de confirmacion
+			</label>
+			<input
+				[id]="'confirm-delete-' + userToDelete.id"
+				type="text"
+				class="delete-input"
+				[value]="deleteNicknameInput()"
+				(input)="onDeleteNicknameInput($event)"
+				[attr.placeholder]="userToDelete.nickname"
+				autocomplete="off"
+			/>
+
+			@if (deleteNicknameInput().length > 0 && !canConfirmDeletion()) {
+				<p class="delete-warning">El nickname no coincide.</p>
+			}
+
+			<footer class="delete-actions">
+				<button type="button" class="action-btn secondary-btn" (click)="closeDeleteModal()">
+					Cancelar
+				</button>
+
+				<button
+					type="button"
+					class="action-btn danger-btn"
+					[disabled]="!canConfirmDeletion()"
+					(click)="confirmDeleteUser()"
+				>
+					Confirmar borrado
+				</button>
+			</footer>
+		</section>
+	</div>
+}

--- a/client/social-network/src/app/pages/admin/admin.ts
+++ b/client/social-network/src/app/pages/admin/admin.ts
@@ -1,4 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, computed, signal } from '@angular/core';
+
+type UserRole = 'admin' | 'user';
+
+type AdminUserRow = {
+  id: number;
+  nickname: string;
+  email: string;
+  avatarPath?: string | null;
+  role: UserRole;
+};
 
 @Component({
   selector: 'app-admin',
@@ -7,5 +17,139 @@ import { Component } from '@angular/core';
   styleUrl: './admin.css',
 })
 export class Admin {
+  protected readonly users = signal<AdminUserRow[]>([
+    {
+      id: 1,
+      nickname: 'rootfire',
+      email: 'rootfire@socialnet.dev',
+      avatarPath: null,
+      role: 'admin',
+    },
+    {
+      id: 2,
+      nickname: 'lia_code',
+      email: 'lia.code@mail.com',
+      avatarPath: null,
+      role: 'user',
+    },
+    {
+      id: 3,
+      nickname: 'neo89',
+      email: 'neo89@socialhub.com',
+      avatarPath: null,
+      role: 'user',
+    },
+    {
+      id: 4,
+      nickname: 'nightowl',
+      email: 'nightowl@socialhub.com',
+      avatarPath: null,
+      role: 'admin',
+    },
+    {
+      id: 5,
+      nickname: 'pixelcat',
+      email: 'pixelcat@mail.com',
+      avatarPath: null,
+      role: 'user',
+    },
+    {
+      id: 6,
+      nickname: 'aura_dev',
+      email: 'aura.dev@mail.com',
+      avatarPath: null,
+      role: 'user',
+    },
+  ]);
+
+  protected readonly selectedUserForDeletion = signal<AdminUserRow | null>(null);
+  protected readonly deleteNicknameInput = signal('');
+  protected readonly actionMessage = signal('');
+
+  protected readonly totalUsers = computed(() => this.users().length);
+  protected readonly totalAdmins = computed(
+    () => this.users().filter((user) => user.role === 'admin').length
+  );
+  protected readonly totalStandardUsers = computed(
+    () => this.totalUsers() - this.totalAdmins()
+  );
+
+  protected readonly canConfirmDeletion = computed(() => {
+    const selectedUser = this.selectedUserForDeletion();
+
+    if (!selectedUser) {
+      return false;
+    }
+
+    return this.deleteNicknameInput().trim() === selectedUser.nickname;
+  });
+
+  protected onRoleChange(userId: number, event: Event): void {
+    const target = event.target as HTMLSelectElement | null;
+
+    if (!target) {
+      return;
+    }
+
+    const selectedRole: UserRole = target.value === 'admin' ? 'admin' : 'user';
+
+    this.users.update((users) =>
+      users.map((user) =>
+        user.id === userId
+          ? {
+              ...user,
+              role: selectedRole,
+            }
+          : user
+      )
+    );
+
+    const editedUser = this.users().find((user) => user.id === userId);
+
+    if (editedUser) {
+      this.actionMessage.set(
+        `Rol actualizado localmente: ${editedUser.nickname} ahora es ${selectedRole}.`
+      );
+    }
+  }
+
+  protected openDeleteModal(user: AdminUserRow): void {
+    this.selectedUserForDeletion.set(user);
+    this.deleteNicknameInput.set('');
+  }
+
+  protected closeDeleteModal(): void {
+    this.selectedUserForDeletion.set(null);
+    this.deleteNicknameInput.set('');
+  }
+
+  protected onDeleteNicknameInput(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    this.deleteNicknameInput.set(target?.value ?? '');
+  }
+
+  protected confirmDeleteUser(): void {
+    const selectedUser = this.selectedUserForDeletion();
+
+    if (!selectedUser || !this.canConfirmDeletion()) {
+      return;
+    }
+
+    this.users.update((users) =>
+      users.filter((user) => user.id !== selectedUser.id)
+    );
+
+    this.actionMessage.set(
+      `Usuario eliminado localmente: ${selectedUser.nickname}.`
+    );
+
+    this.closeDeleteModal();
+  }
+
+  protected onModalOverlayClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      this.closeDeleteModal();
+    }
+  }
 
 }


### PR DESCRIPTION
Implement a full admin panel: add admin.css with styling for the panel, KPI cards, user list, and delete modal; replace the placeholder admin.html with a complete template (KPIs, users list, role selector, deletion confirmation modal). Implement Admin component (admin.ts) using Angular signals and computed values, seeded mock user data, handlers for role changes, delete modal open/close, nickname confirmation input, and local deletion logic. Template is currently a visual placeholder pending backend endpoints integration.